### PR TITLE
fix(povcal): do not insert empty strings into the database

### DIFF
--- a/povcal/insert.py
+++ b/povcal/insert.py
@@ -79,14 +79,13 @@ def main():
 
             values = [
                 (
-                    float(row[variable.slug])
-                    if not np.isnan(row[variable.slug])
-                    else "",
+                    float(row[variable.slug]),
                     int(row["RequestYear"]),
                     entity_name_map[row["CountryName"]],
                     db_variable_id,
                 )
                 for _, row in data_df.iterrows()
+                if not np.isnan(row[variable.slug])
             ]
 
             print("Inserting values...")


### PR DESCRIPTION
**I have not run or tested this.** But given it's a tiny change and that [we won't be running this importer soon](https://owid.slack.com/archives/C01GAN73R5W/p1626945650011400), it might be fine to merge without checking for now?

We don't need to re-run the import because the problem will likely be fixed on the Grapher level instead.

#### Background

There are some issues being reported with charts containing PovCal data, and they seem to arise from having `""` for missing values in the database.

- [Value attributed to wrong category in legend](https://owid.slack.com/archives/C46U9LXRR/p1627120480002300)
- [Value attributed to no category in legend](https://owid.slack.com/archives/C46U9LXRR/p1626935761012500)

The Grapher treats empty strings and missing values differently. Since both categorical and numerical data are supported, and the `data_values.value` table field is a `string` type, it infers mixed types in this case: both categorical and numerical. This affects different charts in different ways.

Ideally, missing values should not get inserted into the database at all. 

