### PR TITLE
fix(db_utils): upsert namespace

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -26,6 +26,8 @@ class DBUtils:
             "entities_inserted": 0,
             "datasets_inserted": 0,
             "datasets_updated": 0,
+            "namespaces_inserted": 0,
+            "namespaces_updated": 0,
             "variables_inserted": 0,
             "variables_updated": 0,
             "sources_inserted": 0,
@@ -198,6 +200,34 @@ class DBUtils:
             self.associate_dataset_tag(dataset_id, tag_id)
 
         return dataset_id
+
+    def upsert_namespace(self, name, description):
+        operation = self.upsert_one(
+            """
+            INSERT INTO namespaces
+                (name, description)
+            VALUES
+                (%s, %s)
+            ON DUPLICATE KEY UPDATE
+                name = VALUES(name),
+                description = VALUES(description)
+        """,
+            [name, description],
+        )
+        (namespace_id,) = self.fetch_one(
+            """
+            SELECT id FROM namespaces
+            WHERE name = %s
+        """,
+            [name],
+        )
+
+        if operation == INSERT:
+            self.counts["namespaces_inserted"] += 1
+        if operation == UPDATE:
+            self.counts["namespaces_updated"] += 1
+
+        return namespace_id
 
     def upsert_source(self, name, description, dataset_id):
         # There is no UNIQUE key constraint we can rely on to prevent duplicates

--- a/standard_importer/import_dataset.py
+++ b/standard_importer/import_dataset.py
@@ -67,7 +67,7 @@ def main(dataset_dir: str, dataset_namespace: str):
         else:
             namespace_description = f"{dataset_dir} datasets"
         db.upsert_namespace(name=dataset_namespace, description=namespace_description)
-        print(f"Upserted 1 namespace.")
+        print("Upserted 1 namespace.")
 
         # Upsert sources
         print("---\nUpserting sources...")

--- a/standard_importer/import_dataset.py
+++ b/standard_importer/import_dataset.py
@@ -60,6 +60,15 @@ def main(dataset_dir: str, dataset_namespace: str):
             datasets.at[i, "db_dataset_id"] = db_dataset_id
         print(f"Upserted {len(datasets)} datasets.")
 
+        # Upsert datasets
+        print("---\nUpserting namespace...")
+        if datasets.shape[0] == 1:
+            namespace_description = datasets["name"].iloc[0]
+        else:
+            namespace_description = f"{dataset_dir} datasets"
+        db.upsert_namespace(name=dataset_namespace, description=namespace_description)
+        print(f"Upserted 1 namespace.")
+
         # Upsert sources
         print("---\nUpserting sources...")
         sources = pd.read_csv(os.path.join(data_path, "sources.csv"))


### PR DESCRIPTION
Upserts a namespace to the `namespaces` MySQL table as part of a dataset import. This makes it easier for authors to use the upserted variables in new charts, because the variable selector modal in the admin chart editor only displays datasets with a namespace in the `namespaces` table.