### PR TITLE
fix(match_variables): add default method for fuzzy matching

### DIFF
--- a/standard_revisions/match_variables_from_two_versions_of_a_dataset.py
+++ b/standard_revisions/match_variables_from_two_versions_of_a_dataset.py
@@ -434,7 +434,7 @@ if __name__ == "__main__":
         "-s",
         "--similarity_name",
         help=f"Name of similarity function to use when fuzzy matching variables. Default: {SIMILARITY_NAME}. "
-        f"Available methods: {', '.join(list(SIMILARITY_NAMES))}.",
+        f"Available methods: {', '.join(list(SIMILARITY_NAMES))}.", default=SIMILARITY_NAME,
     )
     parser.add_argument(
         "-a",

--- a/standard_revisions/match_variables_from_two_versions_of_a_dataset.py
+++ b/standard_revisions/match_variables_from_two_versions_of_a_dataset.py
@@ -434,7 +434,8 @@ if __name__ == "__main__":
         "-s",
         "--similarity_name",
         help=f"Name of similarity function to use when fuzzy matching variables. Default: {SIMILARITY_NAME}. "
-        f"Available methods: {', '.join(list(SIMILARITY_NAMES))}.", default=SIMILARITY_NAME,
+        f"Available methods: {', '.join(list(SIMILARITY_NAMES))}.",
+        default=SIMILARITY_NAME,
     )
     parser.add_argument(
         "-a",


### PR DESCRIPTION
Add default method for fuzzy matching in script `standard_revisions/match_variables_from_two_versions_of_a_dataset.py`. The parser claimed to have a default value for argument "similarity_name", however, no default value was given, therefore forcing the user to always define the similarity_name. Now it is not mandatory to pass the "similarity_name" argument.